### PR TITLE
[1/4] Accessibility foundation: restore core keyboard and screen-reader support

### DIFF
--- a/scripts/shared/accessibility_tests.py
+++ b/scripts/shared/accessibility_tests.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Static accessibility checks for QML UI files.
+
+This suite enforces a baseline of screen-reader semantics and keyboard parity
+for every major feature panel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _require_contains(content: str, needle: str, rel_path: str, errors: list[str]) -> None:
+    if needle not in content:
+        errors.append(f"{rel_path}: missing required snippet `{needle}`")
+
+
+def _run_feature_checks(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+
+    feature_specs: dict[str, dict[str, list[str]]] = {
+        "navigation": {
+            "src/ui/Main.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"Khinsider Downloader\"",
+                "setActiveTab(",
+                "Keys.onPressed",
+            ],
+            "src/ui/shared/SideButton.qml": [
+                "Accessible.role: Accessible.Button",
+                "Accessible.name: accessibleName",
+                "Accessible.description: accessibleDescription",
+                "Keys.onReturnPressed",
+                "Keys.onEnterPressed",
+                "Keys.onSpacePressed",
+            ],
+        },
+        "search": {
+            "src/ui/search/SearchPanel.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"Search panel\"",
+                "Accessible.role: Accessible.EditableText",
+                "Accessible.name: \"Search albums\"",
+                "Qt.Key_Tab",
+                "Qt.Key_Backtab",
+                "accessibleName: \"Add checked albums to downloads\"",
+                "accessibleName: \"Append checked album URLs to download input\"",
+                "Qt.Key_D",
+                "Qt.Key_U",
+            ],
+            "src/ui/search/SearchResultsList.qml": [
+                "Accessible.role: Accessible.List",
+                "Accessible.role: Accessible.CheckBox",
+                "Accessible.selected: isSelected",
+                "Accessible.checkable: true",
+                "Accessible.checked: isChecked",
+                "Accessible.valueChanged()",
+                "activeFocusOnTab: false",
+                "Keys.onUpPressed",
+                "Keys.onDownPressed",
+                "toggleResultChecked(",
+                "addCheckedToDownloads()",
+                "appendCheckedUrlsToDownloadInput()",
+                "model.albumLink",
+            ],
+            "src/ui/search/AlbumInfoSide.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"Selected album details\"",
+            ],
+            "src/ui/search/AlbumImageCaret.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"Album artwork viewer\"",
+                "Keys.onLeftPressed",
+                "Keys.onRightPressed",
+            ],
+            "src/ui/search/AlbumImageCaretButton.qml": [
+                "Accessible.role: Accessible.Button",
+                "Keys.onReturnPressed",
+                "Keys.onEnterPressed",
+                "Keys.onSpacePressed",
+            ],
+        },
+        "download": {
+            "src/ui/download/DownloadPanel.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"Download panel\"",
+                "Accessible.name: \"Album URLs input\"",
+                "downloaderVM.bulkUrlBuffer",
+                "accessibleName: \"Import URLs into download queue\"",
+                "accessibleName: \"Cancel all downloads\"",
+                "Qt.Key_Tab",
+                "Qt.Key_Backtab",
+            ],
+            "src/ui/download/DownloadSide.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"Download queue panel\"",
+                "Accessible.role: Accessible.List",
+            ],
+            "src/ui/download/AlbumItem.qml": [
+                "Accessible.role: Accessible.ListItem",
+                "Accessible.name: \"Retry album download\"",
+                "Accessible.name: \"Cancel album download\"",
+                "Keys.onPressed",
+                "Qt.Key_Delete",
+                "Qt.Key_R",
+            ],
+        },
+        "settings": {
+            "src/ui/settings/SettingsPanel.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"Settings panel\"",
+                "accessibleName: \"Select download path\"",
+                "accessibleName: \"Enable logging\"",
+                "accessibleName: \"Download threads\"",
+                "accessibleName: \"Check for updates\"",
+            ],
+            "src/ui/shared/WEnumButton.qml": [
+                "Accessible.role: Accessible.ComboBox",
+                "Accessible.valueChanged()",
+                "Accessible.name: announceValueOnly ? buttonlabel.text : (accessibleName + \": \" + buttonlabel.text)",
+                "Keys.onUpPressed",
+                "Keys.onDownPressed",
+                "Keys.onLeftPressed",
+                "Keys.onRightPressed",
+            ],
+            "src/ui/shared/WNumberBox.qml": [
+                "Accessible.role: Accessible.SpinBox",
+                "Accessible.valueChanged()",
+                "Accessible.name: accessibleName + \" \" + currentNumber",
+                "Keys.onUpPressed",
+                "Keys.onDownPressed",
+                "Keys.onPressed",
+                "Qt.Key_Home",
+                "Qt.Key_End",
+            ],
+        },
+        "about": {
+            "src/ui/about/AboutPanel.qml": [
+                "Accessible.role: Accessible.Pane",
+                "Accessible.name: \"About panel\"",
+                "Accessible.role: Accessible.List",
+                "Accessible.role: Accessible.ListItem",
+                "activeFocusOnTab: true",
+                "contributorsListScope.focusContributor(",
+                "Accessible.selected: isSelected",
+                "Accessible.role: Accessible.Link",
+            ],
+            "src/ui/about/UpdateCheckerDialog.qml": [
+                "title: \"A new update has been released!\"",
+                "Accessible.role: Accessible.StaticText",
+                "accessibleName: \"Open downloads page\"",
+                "Keys.onEscapePressed",
+            ],
+        },
+        "shared-controls": {
+            "src/ui/shared/WButton.qml": [
+                "Accessible.role: Accessible.Button",
+                "Keys.onReturnPressed",
+                "Keys.onEnterPressed",
+                "Keys.onSpacePressed",
+            ],
+        },
+    }
+
+    for _, file_map in feature_specs.items():
+        for rel_path, needles in file_map.items():
+            path = repo_root / rel_path
+            if not path.exists():
+                errors.append(f"{rel_path}: file is missing")
+                continue
+            content = _read(path)
+            for needle in needles:
+                _require_contains(content, needle, rel_path, errors)
+
+    return errors
+
+
+def _run_generic_checks(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    ui_root = repo_root / "src" / "ui"
+    if not ui_root.exists():
+        return ["src/ui: directory is missing"]
+
+    allow_missing_accessibility = {
+        "src/ui/shared/WScrollView.qml",
+    }
+    allow_mouse_without_keyboard = {
+        "src/ui/shared/WNumberBoxButton.qml",
+    }
+    keyboard_markers = (
+        "Keys.onReturnPressed",
+        "Keys.onEnterPressed",
+        "Keys.onSpacePressed",
+        "Keys.onUpPressed",
+        "Keys.onDownPressed",
+        "Keys.onLeftPressed",
+        "Keys.onRightPressed",
+        "Keys.onHomePressed",
+        "Keys.onEndPressed",
+        "Keys.onPressed",
+    )
+
+    for qml_path in sorted(ui_root.rglob("*.qml")):
+        rel_path = qml_path.relative_to(repo_root).as_posix()
+        content = _read(qml_path)
+
+        if rel_path not in allow_missing_accessibility and "Accessible." not in content:
+            errors.append(f"{rel_path}: expected at least one `Accessible.*` property")
+
+        if "MouseArea" in content and rel_path not in allow_mouse_without_keyboard:
+            if not any(marker in content for marker in keyboard_markers):
+                errors.append(
+                    f"{rel_path}: has MouseArea but no keyboard handling (Keys.on*)."
+                )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run QML accessibility checks")
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root path (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+
+    failures = []
+    failures.extend(_run_feature_checks(repo_root))
+    failures.extend(_run_generic_checks(repo_root))
+
+    if failures:
+        print("Accessibility checks failed:")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print("Accessibility checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pages/download/DownloaderModel.cpp
+++ b/src/pages/download/DownloaderModel.cpp
@@ -1,6 +1,7 @@
 #include "DownloaderModel.h"
 #include "parser/KhinsiderParser.h"
 #include "parser/Album.h"
+#include <QSet>
 
 DownloaderModel::DownloaderModel(QObject *parent) : QAbstractListModel(parent) {
 }
@@ -133,4 +134,31 @@ void DownloaderModel::insertAlbum(Album *album) {
         }
     });
     endInsertRows();
+}
+
+void DownloaderModel::setBulkUrlBuffer(const QString &buffer) {
+    if (m_bulkUrlBuffer == buffer) {
+        return;
+    }
+    m_bulkUrlBuffer = buffer;
+    emit bulkUrlBufferChanged();
+}
+
+void DownloaderModel::appendBulkUrlBuffer(const QString &urls) {
+    QStringList merged = m_bulkUrlBuffer.split('\n', Qt::SkipEmptyParts);
+    QSet<QString> seen;
+    for (const QString &line : merged) {
+        seen.insert(line.trimmed());
+    }
+
+    for (const QString &line : urls.split('\n', Qt::SkipEmptyParts)) {
+        const QString trimmed = line.trimmed();
+        if (trimmed.isEmpty() || seen.contains(trimmed)) {
+            continue;
+        }
+        merged.append(trimmed);
+        seen.insert(trimmed);
+    }
+
+    setBulkUrlBuffer(merged.join('\n'));
 }

--- a/src/pages/download/DownloaderModel.h
+++ b/src/pages/download/DownloaderModel.h
@@ -6,6 +6,7 @@
 
 class DownloaderModel : public QAbstractListModel {
     Q_OBJECT
+    Q_PROPERTY(QString bulkUrlBuffer READ bulkUrlBuffer WRITE setBulkUrlBuffer NOTIFY bulkUrlBufferChanged)
 
 public:
     enum Roles {
@@ -40,6 +41,8 @@ public:
     Q_INVOKABLE int totalDownloadedSongs() const;
 
     Q_INVOKABLE int totalSongs() const;
+    Q_INVOKABLE void appendBulkUrlBuffer(const QString &urls);
+    QString bulkUrlBuffer() const { return m_bulkUrlBuffer; }
 
 public slots:
     void cancelAllDownloads();
@@ -51,6 +54,7 @@ public slots:
     void setAlbums(const QVector<Album *> &albums);
 
     void insertAlbum(Album *album);
+    void setBulkUrlBuffer(const QString &buffer);
 
 signals:
     void albumCancelRequested(Album *album);
@@ -60,9 +64,11 @@ signals:
     void totalsChanged();
 
     void addToDownloadList(const QString &List);
+    void bulkUrlBufferChanged();
 
 private:
     QVector<Album *> m_albums;
+    QString m_bulkUrlBuffer;
 };
 
 #endif // DOWNLOADERMODEL_H

--- a/src/pages/search/SearchResultModel.h
+++ b/src/pages/search/SearchResultModel.h
@@ -11,6 +11,7 @@ class SearchResultModel : public QAbstractListModel {
 public:
     enum Roles {
         NameRole = Qt::UserRole + 1,
+        AlbumLinkRole,
     };
 
     explicit SearchResultModel(QObject *parent = nullptr)
@@ -36,6 +37,8 @@ public:
         switch (role) {
             case NameRole:
                 return album->name();
+            case AlbumLinkRole:
+                return album->albumLink();
         }
 
         return QVariant();
@@ -44,6 +47,7 @@ public:
     QHash<int, QByteArray> roleNames() const override {
         QHash<int, QByteArray> roles;
         roles[NameRole] = "name";
+        roles[AlbumLinkRole] = "albumLink";
         return roles;
     }
 

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -23,10 +23,39 @@ Window {
     visible: true
     color: "#2c3e50"
     title: qsTr("Khinsider Downloader - QT")
+    function setActiveTab(targetState, button) {
+        maincol.state = targetState;
+        slider.jump(button);
+        button.forceActiveFocus();
+    }
+    Keys.onPressed: {
+        if (event.modifiers & Qt.ControlModifier) {
+            if (event.key === Qt.Key_1) {
+                setActiveTab("downloadtab", leftdownloadbutton);
+                event.accepted = true;
+            } else if (event.key === Qt.Key_2) {
+                setActiveTab("searchtab", leftsearchbutton);
+                event.accepted = true;
+            } else if (event.key === Qt.Key_3) {
+                setActiveTab("settingstab", leftsettingsbutton);
+                event.accepted = true;
+            } else if (event.key === Qt.Key_4) {
+                setActiveTab("abouttab", leftaboutbutton);
+                event.accepted = true;
+            }
+        }
+    }
+    Component.onCompleted: {
+        slider.jump(leftdownloadbutton);
+        leftdownloadbutton.forceActiveFocus();
+    }
 
     Column {
         id: maincol
         state: "downloadtab"
+        Accessible.role: Accessible.Pane
+        Accessible.name: "Khinsider Downloader"
+        Accessible.description: "Main application view. Use Ctrl+1 for Download, Ctrl+2 for Search, Ctrl+3 for Settings, and Ctrl+4 for About."
         states: [
             State {
                 name: "downloadtab" //centerPanel
@@ -131,9 +160,10 @@ Window {
                         iconFallback: "../../icons/dl.svg"
                         iconSource: "qrc:/icons/dl.svg"
                         label: "Download"
+                        accessibleName: maincol.state === "downloadtab" ? "Download tab, selected" : "Download tab"
+                        accessibleDescription: "Open the download queue and bulk URL import tools."
                         onClicked: {
-                            maincol.state = "downloadtab"
-                            slider.jump(leftdownloadbutton);
+                            window.setActiveTab("downloadtab", leftdownloadbutton);
                         }
 
                     }
@@ -145,9 +175,10 @@ Window {
                         iconFallback: "../../icons/search.svg"
                         iconSource: "qrc:/icons/search.svg"
                         label: "Search"
+                        accessibleName: maincol.state === "searchtab" ? "Search tab, selected" : "Search tab"
+                        accessibleDescription: "Search albums and add them to the download queue."
                         onClicked: {
-                            maincol.state = "searchtab"
-                            slider.jump(leftsearchbutton);
+                            window.setActiveTab("searchtab", leftsearchbutton);
                         }
                     }
 
@@ -158,9 +189,10 @@ Window {
                         iconFallback: "../../icons/settings.svg"
                         iconSource: "qrc:/icons/settings.svg"
                         label: "Settings"
+                        accessibleName: maincol.state === "settingstab" ? "Settings tab, selected" : "Settings tab"
+                        accessibleDescription: "Configure app behavior and download preferences."
                         onClicked: {
-                            maincol.state = "settingstab"
-                            slider.jump(leftsettingsbutton);
+                            window.setActiveTab("settingstab", leftsettingsbutton);
                         }
                     }
 
@@ -175,9 +207,10 @@ Window {
                         iconFallback: "../../icons/about.svg"
                         iconSource: "qrc:/icons/about.svg"
                         label: "About"
+                        accessibleName: maincol.state === "abouttab" ? "About tab, selected" : "About tab"
+                        accessibleDescription: "View version, contributors, and update information."
                         onClicked: {
-                            maincol.state = "abouttab"
-                            slider.jump(leftaboutbutton);
+                            window.setActiveTab("abouttab", leftaboutbutton);
                         }
                     }
                     Item {

--- a/src/ui/about/AboutPanel.qml
+++ b/src/ui/about/AboutPanel.qml
@@ -10,6 +10,11 @@ Rectangle {
     color: "#2c3e50"
     height: 700
     width: 400
+
+    Accessible.role: Accessible.Pane
+    Accessible.name: "About panel"
+    Accessible.description: "Project information, contributors list, and release links."
+
     Connections {
         target: app.aboutController
         function onFoundNewUpdate() {
@@ -50,80 +55,176 @@ Rectangle {
             Layout.preferredHeight: parent.height * 0.6
             Layout.fillWidth: true
             radius: 10
-            WScrollView {
-                id: scrollView
+            FocusScope {
+                id: contributorsListScope
                 anchors.fill: parent
+                activeFocusOnTab: true
+                property int selectedContributorIndex: -1
 
-                XmlListModel {
-                    id: contributorsModel
-                    source: "qrc:/CONTRIBUTORS.xml"
-                    query: "/contributors/contributor"
-
-                    XmlListModelRole {
-                        name: "username"; elementName: "username"
+                function focusContributor(index) {
+                    if (contributorsModel.count <= 0) {
+                        return;
                     }
-                    XmlListModelRole {
-                        name: "contributionType"; elementName: "contributionType"
+                    var boundedIndex = Math.max(0, Math.min(index, contributorsModel.count - 1));
+                    selectedContributorIndex = boundedIndex;
+                    var item = contributorsRepeater.itemAt(boundedIndex);
+                    if (item) {
+                        item.forceActiveFocus();
                     }
                 }
 
-                Column {
-                    id: column
-                    width: parent.width
-                    height: parent.height
-                    spacing: 5
+                Accessible.role: Accessible.List
+                Accessible.name: "Contributors"
+                Accessible.description: "Contributors list. Use Up and Down arrows to review entries."
+                Accessible.focusable: true
+                Accessible.focused: activeFocus
 
-                    Repeater {
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.top: parent.top
-                        anchors.bottom: parent.bottom
-                        anchors.leftMargin: 10
-                        anchors.rightMargin: 10
-                        anchors.topMargin: 10
-                        anchors.bottomMargin: 10
+                onActiveFocusChanged: {
+                    if (activeFocus && contributorsModel.count > 0) {
+                        focusContributor(selectedContributorIndex >= 0 ? selectedContributorIndex : 0);
+                    }
+                }
+
+                Keys.onUpPressed: {
+                    focusContributor((selectedContributorIndex >= 0 ? selectedContributorIndex : contributorsModel.count) - 1);
+                    event.accepted = true;
+                }
+                Keys.onDownPressed: {
+                    focusContributor((selectedContributorIndex >= 0 ? selectedContributorIndex : -1) + 1);
+                    event.accepted = true;
+                }
+                Keys.onPressed: (event) => {
+                    if (event.key === Qt.Key_Home) {
+                        focusContributor(0);
+                        event.accepted = true;
+                    } else if (event.key === Qt.Key_End) {
+                        focusContributor(contributorsModel.count - 1);
+                        event.accepted = true;
+                    }
+                }
+
+                WScrollView {
+                    id: scrollView
+                    anchors.fill: parent
+
+                    XmlListModel {
+                        id: contributorsModel
+                        source: "qrc:/CONTRIBUTORS.xml"
+                        query: "/contributors/contributor"
+
+                        XmlListModelRole {
+                            name: "username"; elementName: "username"
+                        }
+                        XmlListModelRole {
+                            name: "contributionType"; elementName: "contributionType"
+                        }
+                    }
+
+                    Column {
+                        id: column
                         width: parent.width
-                        model: contributorsModel
+                        height: parent.height
+                        spacing: 5
 
-                        Rectangle {
-                            width: scrollView.width
-                            height: contributorRow.height + 10
-                            color: "transparent"
+                        Repeater {
+                            id: contributorsRepeater
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.bottom: parent.bottom
+                            anchors.leftMargin: 10
+                            anchors.rightMargin: 10
+                            anchors.topMargin: 10
+                            anchors.bottomMargin: 10
+                            width: parent.width
+                            model: contributorsModel
 
-                            RowLayout {
-                                id: contributorRow
+                            Rectangle {
                                 width: scrollView.width
+                                height: contributorRow.height + 10
+                                color: "transparent"
+                                radius: 6
+                                activeFocusOnTab: false
+                                property bool isSelected: index === contributorsListScope.selectedContributorIndex
+                                border.width: activeFocus ? 2 : (isSelected ? 1 : 0)
+                                border.color: activeFocus ? "#ffffff" : (isSelected ? "#d0ecff" : "transparent")
 
-                                anchors.verticalCenter: parent.verticalCenter
+                                Accessible.role: Accessible.ListItem
+                                Accessible.name: username + ", " + contributionType
+                                Accessible.description: "Contributor " + (index + 1) + " of " + contributorsModel.count + ". " + (isSelected ? "Selected" : "Not selected")
+                                Accessible.focusable: true
+                                Accessible.focused: activeFocus
+                                Accessible.selectable: true
+                                Accessible.selected: isSelected
 
-                                Text {
-                                    Layout.leftMargin: 10
-                                    text: username
-                                    color: "white"
-                                    font.pointSize: 13
-                                    elide: Text.ElideRight
-                                    verticalAlignment: Text.AlignVCenter
+                                onActiveFocusChanged: {
+                                    if (activeFocus) {
+                                        contributorsListScope.selectedContributorIndex = index;
+                                    }
                                 }
 
-                                Item {
-
-                                    Layout.fillHeight: true
-                                    Layout.fillWidth: true
+                                Keys.onUpPressed: {
+                                    contributorsListScope.focusContributor(index - 1);
+                                    event.accepted = true;
+                                }
+                                Keys.onDownPressed: {
+                                    contributorsListScope.focusContributor(index + 1);
+                                    event.accepted = true;
+                                }
+                                Keys.onPressed: (event) => {
+                                    if (event.key === Qt.Key_Home) {
+                                        contributorsListScope.focusContributor(0);
+                                        event.accepted = true;
+                                    } else if (event.key === Qt.Key_End) {
+                                        contributorsListScope.focusContributor(contributorsModel.count - 1);
+                                        event.accepted = true;
+                                    }
                                 }
 
-                                Text {
-                                    Layout.rightMargin: 10
-                                    text: contributionType
-                                    color: "white"
-                                    font.pointSize: 13
-                                    elide: Text.ElideRight
-                                    verticalAlignment: Text.AlignVCenter
+                                MouseArea {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        contributorsListScope.focusContributor(index);
+                                    }
+                                }
+
+                                RowLayout {
+                                    id: contributorRow
+                                    width: scrollView.width
+
+                                    anchors.verticalCenter: parent.verticalCenter
+
+                                    Text {
+                                        Layout.leftMargin: 10
+                                        text: username
+                                        color: "white"
+                                        font.pointSize: 13
+                                        elide: Text.ElideRight
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+
+                                    Item {
+
+                                        Layout.fillHeight: true
+                                        Layout.fillWidth: true
+                                    }
+
+                                    Text {
+                                        Layout.rightMargin: 10
+                                        text: contributionType
+                                        color: "white"
+                                        font.pointSize: 13
+                                        elide: Text.ElideRight
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
+                }
             }
         }
         Item {
@@ -152,6 +253,32 @@ Rectangle {
                 color: "white"
                 onLinkActivated: Qt.openUrlExternally(link)
                 font.pointSize: 16
+                activeFocusOnTab: true
+
+                Accessible.role: Accessible.Link
+                Accessible.name: "Open Weespin website"
+                Accessible.focusable: true
+                Accessible.focused: activeFocus
+
+                Keys.onReturnPressed: {
+                    Qt.openUrlExternally("https://weesp.in");
+                    event.accepted = true;
+                }
+                Keys.onEnterPressed: {
+                    Qt.openUrlExternally("https://weesp.in");
+                    event.accepted = true;
+                }
+                Keys.onSpacePressed: {
+                    Qt.openUrlExternally("https://weesp.in");
+                    event.accepted = true;
+                }
+                Rectangle {
+                    anchors.fill: parent
+                    color: "transparent"
+                    border.width: parent.activeFocus ? 2 : 0
+                    border.color: parent.activeFocus ? "#ffffff" : "transparent"
+                    radius: 4
+                }
             }
         }
 

--- a/src/ui/about/UpdateCheckerDialog.qml
+++ b/src/ui/about/UpdateCheckerDialog.qml
@@ -11,8 +11,14 @@ Window {
     id: window
     visible: true
     color: "#2c3e50"
+    modality: Qt.ApplicationModal
     signal accepted
     title: "A new update has been released!"
+    Component.onCompleted: okButton.forceActiveFocus()
+    Keys.onEscapePressed: {
+        window.visible = false;
+        event.accepted = true;
+    }
     Column
     {
         width: parent.width
@@ -27,16 +33,22 @@ Window {
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             wrapMode: Text.WordWrap
+
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
         }
         WButton
         {
+            id: okButton
             anchors.horizontalCenter: parent.horizontalCenter
             width :parent.width * 0.5
             label: "OK"
+            accessibleName: "Open downloads page"
             height: parent.height * 0.15
             onClicked:
             {
                 accepted();
+                window.visible = false;
             }
         }
 

--- a/src/ui/download/AlbumItem.qml
+++ b/src/ui/download/AlbumItem.qml
@@ -1,295 +1,344 @@
 import QtQuick 2.15
-import Qt5Compat.GraphicalEffects
 import QtQuick.Layouts
 
 Item {
-       state: "errored"
+    id: root
+    state: "errored"
 
-       signal cancelRequested();
-       signal retryRequested();
-       property var donwloadedSongs;
-       property var totalSongs;
-       property var speedInBytes;
-       function formatSpeed(bytesPerSecond) {
-           if (bytesPerSecond >= 1024 * 1024) {
-               return (bytesPerSecond / (1024 * 1024)).toFixed(2) + " MB/s";
-           } else if (bytesPerSecond >= 1024) {
-               return (bytesPerSecond / 1024).toFixed(2) + " KB/s";
-           } else {
-               return bytesPerSecond + " B/s";
-           }
-       }
-       onDonwloadedSongsChanged:
-       {
-              fileslabel.text = "Files: " + donwloadedSongs + "/" + totalSongs;
-       }
+    signal cancelRequested()
+    signal retryRequested()
+    property var donwloadedSongs
+    property var totalSongs
+    property var speedInBytes
+    property bool showActionOverlay: hoverArea.containsMouse || activeFocus || retryButton.activeFocus || deleteButton.activeFocus
 
-       onSpeedInBytesChanged:
-       {
-              downloadstatus.text =  "Speed: " + formatSpeed(speedInBytes);
-       }
+    property alias progress: percentageBar.percentage
+    property alias label: albumName.text
 
-       states: [
-              State {
-                     name: "downloading"
-                     PropertyChanges { target: percentagebar; color:"#4CAF50" }
-                     PropertyChanges { target: mainrect; color:"#6C98C4" }
-                     PropertyChanges { target: perclabel; visible: true}
-                     PropertyChanges { target: downloadstatus; visible: true }
-                     PropertyChanges { target: fileslabel; visible: true }
-                     PropertyChanges { target: restartbutton; visible: false }
+    height: 50
+    width: 400
+    activeFocusOnTab: true
 
-              },
-              State {
-                     name: "unparsed"
-                     PropertyChanges { target: percentagebar; color:"transparent" }
-                     PropertyChanges { target: mainrect; color:"#FFA000" }
-                     PropertyChanges { target: perclabel; visible: false}
-                     PropertyChanges { target: downloadstatus; visible: false }
-                     PropertyChanges { target: fileslabel; visible: false }
-                     PropertyChanges { target: restartbutton; visible: false }
+    Accessible.role: Accessible.ListItem
+    Accessible.name: albumName.text
+    Accessible.description: "State: " + root.state + ". Progress " + percentageBar.percentage + " percent. " + filesLabel.text + ". " + downloadStatus.text + ". Press Delete to cancel or R to retry when available."
+    Accessible.focusable: true
+    Accessible.focused: activeFocus
 
-              },
-              State {
-                     name: "parsed"
-                     PropertyChanges { target: percentagebar; color:"transparent" }
-                     PropertyChanges { target: mainrect; color:"#6C98C4" }
-                     PropertyChanges { target: perclabel; visible: false}
-                     PropertyChanges { target: downloadstatus; visible: true }
-                     PropertyChanges { target: fileslabel; visible: true }
-                      PropertyChanges { target: restartbutton; visible: false }
+    function formatSpeed(bytesPerSecond) {
+        if (bytesPerSecond >= 1024 * 1024) {
+            return (bytesPerSecond / (1024 * 1024)).toFixed(2) + " MB/s";
+        } else if (bytesPerSecond >= 1024) {
+            return (bytesPerSecond / 1024).toFixed(2) + " KB/s";
+        } else {
+            return bytesPerSecond + " B/s";
+        }
+    }
+    function requestCancel() {
+        if (!enabled) {
+            return;
+        }
+        cancelRequested();
+    }
+    function requestRetry() {
+        if (!enabled || !retryButton.visible) {
+            return;
+        }
+        retryRequested();
+    }
 
-              },
-              State {
-                     name: "errored"
-                     PropertyChanges { target: percentagebar; color:"transparent" }
-                     PropertyChanges { target: mainrect; color:"#D32F2F" }
-                     PropertyChanges { target: perclabel; visible: false}
-                     PropertyChanges { target: downloadstatus; visible: false }
-                     PropertyChanges { target: fileslabel; visible: true }
-                     PropertyChanges { target: restartbutton; visible: true }
+    onDonwloadedSongsChanged: {
+        filesLabel.text = "Files: " + donwloadedSongs + "/" + totalSongs;
+    }
+    onSpeedInBytesChanged: {
+        downloadStatus.text = "Speed: " + formatSpeed(speedInBytes);
+    }
 
-              }
-       ]
-       property alias progress: percentagebar.percentage;
-       property alias label: albumname.text
-       height: 50
-       width: 400
-       Rectangle
-       {
-              MouseArea{
-                     width: parent.width
-                     height: parent.height
-                     hoverEnabled: true
-                     onEntered:
-                     {
-                            downloaderRow.visible = false
-                            darkoverlay.visible = true;
-                     }
-                     onExited:
-                     {
-                            downloaderRow.visible = true;
-                            darkoverlay.visible = false;
-                     }
+    Keys.onPressed: (event) => {
+        if (event.key === Qt.Key_Delete || event.key === Qt.Key_Backspace) {
+            requestCancel();
+            event.accepted = true;
+        } else if (event.key === Qt.Key_R) {
+            requestRetry();
+            event.accepted = true;
+        }
+    }
 
-              }
+    states: [
+        State {
+            name: "downloading"
+            PropertyChanges { target: percentageBar; color:"#4CAF50" }
+            PropertyChanges { target: mainRect; color:"#6C98C4" }
+            PropertyChanges { target: percentageLabel; visible: true}
+            PropertyChanges { target: downloadStatus; visible: true }
+            PropertyChanges { target: filesLabel; visible: true }
+            PropertyChanges { target: retryButton; visible: false }
 
-              layer.enabled: true
-              layer.effect: OpacityMask{
-                     maskSource: Item{
-                            width: mainrect.width
-                            height: mainrect.height
-                            Rectangle{
+        },
+        State {
+            name: "unparsed"
+            PropertyChanges { target: percentageBar; color:"transparent" }
+            PropertyChanges { target: mainRect; color:"#FFA000" }
+            PropertyChanges { target: percentageLabel; visible: false}
+            PropertyChanges { target: downloadStatus; visible: false }
+            PropertyChanges { target: filesLabel; visible: false }
+            PropertyChanges { target: retryButton; visible: false }
 
-                                   width: parent.width
+        },
+        State {
+            name: "parsed"
+            PropertyChanges { target: percentageBar; color:"transparent" }
+            PropertyChanges { target: mainRect; color:"#6C98C4" }
+            PropertyChanges { target: percentageLabel; visible: false}
+            PropertyChanges { target: downloadStatus; visible: true }
+            PropertyChanges { target: filesLabel; visible: true }
+            PropertyChanges { target: retryButton; visible: false }
 
-                                   height: parent.height
-                                   radius: 20
+        },
+        State {
+            name: "errored"
+            PropertyChanges { target: percentageBar; color:"transparent" }
+            PropertyChanges { target: mainRect; color:"#D32F2F" }
+            PropertyChanges { target: percentageLabel; visible: false}
+            PropertyChanges { target: downloadStatus; visible: false }
+            PropertyChanges { target: filesLabel; visible: true }
+            PropertyChanges { target: retryButton; visible: true }
+
+        }
+    ]
+
+    Rectangle {
+        id: mainRect
+        color: "#6C98C4"
+        width: parent.width
+        height: parent.height
+        radius: 20
+        border.width: root.activeFocus ? 2 : 0
+        border.color: root.activeFocus ? "#ffffff" : "transparent"
+
+        MouseArea {
+            id: hoverArea
+            width: parent.width
+            height: parent.height
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+                root.forceActiveFocus();
+            }
+        }
+
+        Rectangle {
+            property int percentage
+            id: percentageBar
+            color: "#4CAF50"
+            width: (percentageBar.percentage / 100) * mainRect.width
+            height: parent.height
+            radius: 20
+
+            onPercentageChanged: {
+                percentageBar.width = (percentageBar.percentage / 100) * mainRect.width;
+            }
+
+            Behavior on width {
+                NumberAnimation {
+                    duration: 100
+                    easing.type: Easing.InOutQuad
+                }
+            }
+        }
+
+        Row {
+            id: downloaderRow
+            width: parent.width
+            height: parent.height
+            visible: !root.showActionOverlay
+
+            Text {
+                id: albumName
+                width: parent.width * 0.75
+                height: parent.height
+                text: model.name
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignLeft
+                color: "white"
+                verticalAlignment: Text.AlignVCenter
+                leftPadding: 7
+                font.bold: false
+                font.pointSize: 14
+            }
+
+            Text {
+                id: percentageLabel
+                width: parent.width * 0.25
+                height: parent.height
+                text: percentageBar.percentage + "%"
+                color: "white"
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignRight
+                verticalAlignment: Text.AlignVCenter
+                rightPadding: 10
+                font.bold: false
+                font.pointSize: 14
+            }
+        }
+
+        Rectangle {
+            id: darkOverlay
+            visible: root.showActionOverlay
+            width: parent.width
+            height: parent.height
+            color: "#bc000000"
+
+            Item {
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: parent.width * 0.95
+                height: parent.height
+
+                RowLayout {
+                    spacing: 10
+                    width: parent.width
+                    height: parent.height
+
+                    Text {
+                        id: filesLabel
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: Math.min(implicitWidth, parent.width * 0.4)
+                        Layout.maximumWidth: parent.width * 0.4
+                        text: "Files: 0/0"
+                        elide: Text.ElideRight
+                        color: "white"
+                        horizontalAlignment: Text.AlignLeft
+                        verticalAlignment: Text.AlignVCenter
+                        font.pointSize: 14
+                    }
+
+                    Text {
+                        id: downloadStatus
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: Math.min(implicitWidth, parent.width * 0.4)
+                        Layout.maximumWidth: parent.width * 0.4
+                        text: "Speed: 0 B/s"
+                        elide: Text.ElideRight
+                        color: "white"
+                        horizontalAlignment: Text.AlignLeft
+                        verticalAlignment: Text.AlignVCenter
+                        font.pointSize: 14
+                    }
+
+                    Image {
+                        id: retryButton
+                        Layout.preferredWidth: 60 * 0.5
+                        Layout.fillHeight: true
+                        Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                        visible: true
+                        property string iconFallback: "qrc:/icons/retry.svg"
+                        source: "../../../icons/retry.svg"
+                        fillMode: Image.PreserveAspectFit
+                        activeFocusOnTab: visible
+
+                        Accessible.role: Accessible.Button
+                        Accessible.name: "Retry album download"
+                        Accessible.focusable: visible
+                        Accessible.focused: activeFocus
+
+                        Keys.onReturnPressed: {
+                            root.requestRetry();
+                            event.accepted = true;
+                        }
+                        Keys.onEnterPressed: {
+                            root.requestRetry();
+                            event.accepted = true;
+                        }
+                        Keys.onSpacePressed: {
+                            root.requestRetry();
+                            event.accepted = true;
+                        }
+
+                        MouseArea {
+                            hoverEnabled: false
+                            width: parent.width
+                            height: parent.height
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.requestRetry();
                             }
-                     }
-              }
+                        }
 
-              id:mainrect
-              color: "#6C98C4" // background
-              width: parent.width
-              height: parent.height
-              radius: 20
+                        Rectangle {
+                            anchors.fill: parent
+                            color: "transparent"
+                            border.width: retryButton.activeFocus ? 2 : 0
+                            border.color: retryButton.activeFocus ? "#ffffff" : "transparent"
+                            radius: 5
+                        }
 
-              Rectangle
-              {
-                     property int percentage;
-                     id: percentagebar
-                     color: "#4CAF50"
-                     width: (percentagebar.percentage / 100) * mainrect.width
-                     height: parent.height
-                     radius: 20
-
-                     onPercentageChanged:
-                     {
-                            percentagebar.width = (percentagebar.percentage / 100) * mainrect.width
-                     }
-
-                     Behavior on width {
-                         NumberAnimation {
-                             duration: 100
-                             easing.type: Easing.InOutQuad
-                         }
-                     }
-              }
-              Row
-              {
-                     id:downloaderRow
-                     width: parent.width
-                     height: parent.height
-                     Text
-                     {
-
-                            width: parent.width * 0.75
-
-                            height: parent.height
-                            id: albumname;
-                            text:model.name;
-                            elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignLeft
-                            color:"white"
-                            verticalAlignment: Text.AlignVCenter
-                            leftPadding: 7
-                            font.bold: false
-                            font.pointSize: 14
-                     }
-                     Text
-                     {
-                            width: parent.width * 0.25
-                            height: parent.height
-                            id: perclabel;
-                            text: percentagebar.percentage + "%"
-                            color:"white"
-                            elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignRight
-                            verticalAlignment: Text.AlignVCenter
-                            rightPadding: 10
-                            font.bold: false
-                            font.pointSize: 14
-                     }
-              }
-
-              Rectangle {
-
-                     visible: false
-                     width: parent.width
-                     height: parent.height
-                     color: "#bc000000"
-                     id: darkoverlay
-
-                     Item {
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            width: parent.width * 0.95
-                            height: parent.height
-
-                            RowLayout {
-                                spacing: 10
-                                width: parent.width
-                                height: parent.height
-
-                                Text {
-                                    Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-                                    id: fileslabel
-                                    Layout.fillHeight: true
-                                    //Layout.preferredWidth: implicitWidth;
-                                    Layout.preferredWidth: Math.min(implicitWidth, parent.width * 0.4)
-                                    Layout.maximumWidth: parent.width * 0.4
-                                    text: "Files: 50/136"
-                                    elide: Text.ElideRight
-                                    color: "white"
-                                    horizontalAlignment: Text.AlignLeft
-                                    verticalAlignment: Text.AlignVCenter
-                                    font.pointSize: 14
-                                }
-
-                                Text {
-                                    Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-                                    id: downloadstatus
-                                    Layout.fillHeight: true
-                                    //Layout.preferredWidth: implicitWidth;
-                                    Layout.preferredWidth: Math.min(implicitWidth, parent.width * 0.4)
-                                    Layout.maximumWidth: parent.width * 0.4
-                                    text: "10MB/20MB @50KB/s"
-                                    elide: Text.ElideRight
-                                    color: "white"
-                                    horizontalAlignment: Text.AlignLeft
-                                    verticalAlignment: Text.AlignVCenter
-                                    font.pointSize: 14
-                                }
-
-                              //Item
-                              //{
-                              //   Layout.fillWidth: true
-                              //   Layout.fillHeight: true
-                              //}
-                                Image {
-                                    id: restartbutton
-                                    Layout.preferredWidth: 60 * 0.5
-                                    Layout.fillHeight: true
-                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                    // Remove the anchors.right property
-                                    visible: true
-                                    property string iconFallback: "qrc:/icons/retry.svg"
-                                    source: "../../../icons/retry.svg"
-                                    fillMode: Image.PreserveAspectFit
-
-                                    ColorOverlay {
-                                        anchors.fill: parent
-                                        source: parent
-                                        color: "white"
-                                    }
-                                    MouseArea
-                                    {
-                                          hoverEnabled: false;
-                                          width: parent.width
-                                          height: parent.height
-                                          onClicked:
-                                          {
-                                              retryRequested();
-                                          }
-                                    }
-
-                                    onStatusChanged: {
-                                        if (status === Image.Error) {
-                                            source = iconFallback;
-                                        }
-                                    }
-                                }
-                                Image {
-                                    id: deletebutton
-                                    Layout.preferredWidth: 30
-                                    Layout.preferredHeight: parent.height * 0.8
-                                    Layout.fillHeight: true
-                                    visible: true
-                                    property string iconFallback: "qrc:/icons/delete.svg"
-                                    source: "../../../icons/delete.svg"
-                                    Layout.rightMargin: 5
-                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-
-                                    fillMode: Image.PreserveAspectFit
-                                    MouseArea
-                                    {
-                                          hoverEnabled: false;
-                                          width: parent.width
-                                          height: parent.height
-                                          onClicked:
-                                          {
-                                                 cancelRequested();
-                                          }
-                                    }
-
-                                    onStatusChanged: {
-                                        if (status === Image.Error) {
-                                            source = iconFallback;
-                                        }
-                                    }
-                                }
+                        onStatusChanged: {
+                            if (status === Image.Error) {
+                                source = iconFallback;
                             }
-                     }
-              }
-       }
+                        }
+                    }
+
+                    Image {
+                        id: deleteButton
+                        Layout.preferredWidth: 30
+                        Layout.preferredHeight: parent.height * 0.8
+                        Layout.fillHeight: true
+                        visible: true
+                        property string iconFallback: "qrc:/icons/delete.svg"
+                        source: "../../../icons/delete.svg"
+                        Layout.rightMargin: 5
+                        Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+
+                        fillMode: Image.PreserveAspectFit
+                        activeFocusOnTab: visible
+
+                        Accessible.role: Accessible.Button
+                        Accessible.name: "Cancel album download"
+                        Accessible.focusable: visible
+                        Accessible.focused: activeFocus
+
+                        Keys.onReturnPressed: {
+                            root.requestCancel();
+                            event.accepted = true;
+                        }
+                        Keys.onEnterPressed: {
+                            root.requestCancel();
+                            event.accepted = true;
+                        }
+                        Keys.onSpacePressed: {
+                            root.requestCancel();
+                            event.accepted = true;
+                        }
+
+                        MouseArea {
+                            hoverEnabled: false
+                            width: parent.width
+                            height: parent.height
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.requestCancel();
+                            }
+                        }
+
+                        Rectangle {
+                            anchors.fill: parent
+                            color: "transparent"
+                            border.width: deleteButton.activeFocus ? 2 : 0
+                            border.color: deleteButton.activeFocus ? "#ffffff" : "transparent"
+                            radius: 5
+                        }
+
+                        onStatusChanged: {
+                            if (status === Image.Error) {
+                                source = iconFallback;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/ui/download/DownloadPanel.qml
+++ b/src/ui/download/DownloadPanel.qml
@@ -7,6 +7,16 @@ Item {
     //todo: show speed per album, MB/MB stop button (delete)
     width: 800
     height: 600
+    Accessible.role: Accessible.Pane
+    Accessible.name: "Download panel"
+    Accessible.description: "Import album URLs and control the download queue."
+    function importBulkUrls() {
+        app.downloaderController.downloaderVM.addToDownloadList(textfield.text);
+        app.downloaderController.downloaderVM.bulkUrlBuffer = "";
+    }
+    function cancelAllDownloads() {
+        app.downloaderController.downloaderVM.cancelAllDownloads();
+    }
     Rectangle {
         id:mainWindow
         state: "normal"
@@ -66,6 +76,7 @@ Item {
                                 {
                                     hoverEnabled: true
                                     id: textfield
+                                    text: app.downloaderController.downloaderVM.bulkUrlBuffer
                                     height: parent.height
                                     color: "#ffffff"
                                     font.pointSize: 13
@@ -73,6 +84,39 @@ Item {
                                     placeholderText: "URLs here"
                                     width: parent.width
                                     background:null
+                                    activeFocusOnTab: true
+
+                                    Accessible.role: Accessible.EditableText
+                                    Accessible.name: "Album URLs input"
+                                    Accessible.description: "Paste one URL per line and press Import."
+                                    Accessible.focusable: true
+                                    Accessible.focused: activeFocus
+
+                                    onTextChanged: {
+                                        if (app.downloaderController.downloaderVM.bulkUrlBuffer !== text) {
+                                            app.downloaderController.downloaderVM.bulkUrlBuffer = text;
+                                        }
+                                    }
+
+                                    function focusNextEditableTarget(forward) {
+                                        var nextItem = textfield.nextItemInFocusChain(forward);
+                                        if (nextItem && nextItem !== textfield) {
+                                            nextItem.forceActiveFocus();
+                                        }
+                                    }
+
+                                    Keys.onPressed: (event) => {
+                                        if (event.key === Qt.Key_Backtab || (event.key === Qt.Key_Tab && (event.modifiers & Qt.ShiftModifier))) {
+                                            textfield.focusNextEditableTarget(false);
+                                            event.accepted = true;
+                                        } else if (event.key === Qt.Key_Tab && event.modifiers === Qt.NoModifier) {
+                                            textfield.focusNextEditableTarget(true);
+                                            event.accepted = true;
+                                        } else if ((event.modifiers & Qt.ControlModifier) && (event.key === Qt.Key_Return || event.key === Qt.Key_Enter)) {
+                                            root.importBulkUrls();
+                                            event.accepted = true;
+                                        }
+                                    }
 
                                     PropertyAnimation {
                                         id: onPlaceholderHover
@@ -115,10 +159,11 @@ Item {
 
                         Layout.preferredWidth: parent.width * 0.8
                         label: "Import"
+                        accessibleName: "Import URLs into download queue"
+                        accessibleDescription: "Import the URLs entered above into the download queue."
                         onClicked:
                         {
-                            app.downloaderController.downloaderVM.addToDownloadList(textfield.text);
-                            textfield.text = "";
+                            root.importBulkUrls();
                             //mainWindow.state = (mainWindow.state === "normal") ? "expanded" : "normal"
                         }
                     }
@@ -127,9 +172,11 @@ Item {
                         Layout.preferredHeight: 45
                         Layout.preferredWidth: parent.width * 0.8
                         Layout.alignment: Qt.AlignCenter
+                        accessibleName: "Cancel all downloads"
+                        accessibleDescription: "Stop every active and queued download."
                         onClicked:
                         {
-                            app.downloaderController.downloaderVM.cancelAllDownloads();
+                            root.cancelAllDownloads();
                         }
                         label: "Cancel All"
                     }

--- a/src/ui/download/DownloadSide.qml
+++ b/src/ui/download/DownloadSide.qml
@@ -7,6 +7,11 @@ Rectangle
        id:root
        height: 800
        width: 600
+
+       Accessible.role: Accessible.Pane
+       Accessible.name: "Download queue panel"
+       Accessible.description: "Shows queued albums and live download status."
+
        WScrollView
        {
               id: scrollView
@@ -20,6 +25,9 @@ Rectangle
 
               Column
               {
+                     Accessible.role: Accessible.List
+                     Accessible.name: "Download queue list"
+                     Accessible.description: "Each item reports status, progress, and actions."
 
                      width: root.width * 0.92;
                      height: root.height;
@@ -78,6 +86,9 @@ Rectangle
                             font.pointSize: 16
                             horizontalAlignment: Text.AlignHCenter
                             verticalAlignment: Text.AlignVCenter
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: "Total download speed"
+                            Accessible.description: text
                             function formatSpeed(bytesPerSecond) {
                                    if (bytesPerSecond >= 1024 * 1024) {
                                           return (bytesPerSecond / (1024 * 1024)).toFixed(2) + " MB/s";
@@ -117,6 +128,9 @@ Rectangle
                             opacity: 0
                             horizontalAlignment: Text.AlignHCenter
                             verticalAlignment: Text.AlignVCenter
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: "Downloaded songs"
+                            Accessible.description: text
                             Behavior on opacity {
                                  NumberAnimation {
                                      duration: 100

--- a/src/ui/search/AlbumImageCaretButton.qml
+++ b/src/ui/search/AlbumImageCaretButton.qml
@@ -3,6 +3,35 @@ import QtQuick
 Image {
 
     signal requestImageChange()
+    property string accessibleName: "Change album image"
+    property string accessibleDescription: ""
+    activeFocusOnTab: true
+
+    Accessible.role: Accessible.Button
+    Accessible.name: accessibleName
+    Accessible.description: accessibleDescription
+    Accessible.focusable: enabled
+    Accessible.focused: activeFocus
+
+    function activateButton() {
+        if (!enabled) {
+            return;
+        }
+        requestImageChange();
+    }
+
+    Keys.onReturnPressed: {
+        activateButton();
+        event.accepted = true;
+    }
+    Keys.onEnterPressed: {
+        activateButton();
+        event.accepted = true;
+    }
+    Keys.onSpacePressed: {
+        activateButton();
+        event.accepted = true;
+    }
 
     SequentialAnimation {
         id: shrinkAnim
@@ -21,6 +50,8 @@ Image {
     MouseArea {
         anchors.fill: parent
         hoverEnabled: true
+        enabled: arrow.enabled
+        cursorShape: Qt.PointingHandCursor
         onPressed: {
             shrinkAnim.running = true
         }
@@ -37,7 +68,7 @@ Image {
         }
         onClicked:
         {
-            requestImageChange();
+            activateButton();
         }
     }
 
@@ -45,5 +76,13 @@ Image {
     source: "qrc:/icons/arrowleft.svg"
     mirror: true
     fillMode: Image.PreserveAspectFit
+
+    Rectangle {
+        anchors.fill: parent
+        color: "transparent"
+        border.width: arrow.activeFocus ? 2 : 0
+        border.color: arrow.activeFocus ? "#ffffff" : "transparent"
+        radius: 6
+    }
 
 }

--- a/src/ui/search/AlbumInfoSide.qml
+++ b/src/ui/search/AlbumInfoSide.qml
@@ -9,6 +9,10 @@ Rectangle {
     height: 500
     width: 200
 
+    Accessible.role: Accessible.Pane
+    Accessible.name: "Selected album details"
+    Accessible.description: "Album information and format download actions for the selected search result."
+
     ColumnLayout {
         anchors.fill:parent
         spacing: 5
@@ -48,6 +52,9 @@ Rectangle {
                         width: parent.width
                         horizontalAlignment: Text.AlignLeft
                         verticalAlignment: Text.AlignVCenter
+                        Accessible.role: Accessible.StaticText
+                        Accessible.name: modelData.label
+                        Accessible.description: modelData.value
                     }
                 }
 
@@ -73,6 +80,8 @@ Rectangle {
                         width: parent.width * 0.6
                         anchors.horizontalCenter: parent.horizontalCenter
                         label: "Add " + modelData
+                        accessibleName: "Add album as " + modelData
+                        accessibleDescription: "Add the selected album to downloads in " + modelData + " format."
                         opacity:0
                         Behavior on opacity {
                             NumberAnimation {

--- a/src/ui/search/SearchResultsList.qml
+++ b/src/ui/search/SearchResultsList.qml
@@ -4,10 +4,94 @@ import "../shared"
 
 Item {
     id: root
+    property var checkedResults: ({})
+    property int checkedCount: 0
+    property int checkedRevision: 0
     function hideAllResults()
     {
         root.isSearching = true;
-        root.selectedIndex = -1;
+        root.clearCheckedResults();
+        app.searchController.searchResultVM.setSelectedIndex(-1);
+    }
+    function selectResult(resultIndex) {
+        if (resultIndex < 0 || resultIndex >= resultRepeater.count) {
+            return;
+        }
+        app.searchController.searchResultVM.setSelectedIndex(resultIndex);
+    }
+    function isResultChecked(resultIndex) {
+        return checkedResults[resultIndex] === true;
+    }
+    function setResultChecked(resultIndex, checked) {
+        if (resultIndex < 0 || resultIndex >= resultRepeater.count) {
+            return;
+        }
+        var previouslyChecked = root.isResultChecked(resultIndex);
+        if (previouslyChecked === checked) {
+            return;
+        }
+        if (checked) {
+            checkedResults[resultIndex] = true;
+            checkedCount++;
+        } else {
+            delete checkedResults[resultIndex];
+            checkedCount = Math.max(0, checkedCount - 1);
+        }
+        checkedRevision++;
+    }
+    function toggleResultChecked(resultIndex) {
+        setResultChecked(resultIndex, !isResultChecked(resultIndex));
+    }
+    function clearCheckedResults() {
+        checkedResults = ({});
+        checkedCount = 0;
+        checkedRevision++;
+    }
+    function checkedAlbumLinks() {
+        var links = [];
+        for (var i = 0; i < resultRepeater.count; i++) {
+            if (!isResultChecked(i)) {
+                continue;
+            }
+            var item = resultRepeater.itemAt(i);
+            if (item && item.albumLink && item.albumLink.length > 0) {
+                links.push(item.albumLink);
+            }
+        }
+        if (links.length === 0 && selectedIndex >= 0) {
+            var selectedItem = resultRepeater.itemAt(selectedIndex);
+            if (selectedItem && selectedItem.albumLink && selectedItem.albumLink.length > 0) {
+                links.push(selectedItem.albumLink);
+            }
+        }
+        return links;
+    }
+    function checkedAlbumLinksText() {
+        return checkedAlbumLinks().join("\n");
+    }
+    function addCheckedToDownloads() {
+        var linksText = checkedAlbumLinksText();
+        if (linksText.length === 0) {
+            return;
+        }
+        app.downloaderController.downloaderVM.addToDownloadList(linksText);
+    }
+    function appendCheckedUrlsToDownloadInput() {
+        var linksText = checkedAlbumLinksText();
+        if (linksText.length === 0) {
+            return;
+        }
+        app.downloaderController.downloaderVM.appendBulkUrlBuffer(linksText);
+    }
+    function focusResult(resultIndex) {
+        if (resultIndex < 0 || resultIndex >= resultRepeater.count) {
+            return;
+        }
+        selectResult(resultIndex);
+        var item = resultRepeater.itemAt(resultIndex);
+        if (item) {
+            item.forceActiveFocus();
+        }
     }
 
     property int selectedIndex: app.searchController.searchResultVM.selectedIndex
@@ -15,6 +99,16 @@ Item {
 
     height: 600
     width: 600
+
+    Accessible.role: Accessible.List
+    Accessible.name: "Search results"
+    Accessible.description: "Album search results. Use Up and Down arrows to move, Space to check albums, Ctrl+D to queue checked albums, and Ctrl+U to append checked URLs to download input."
+    activeFocusOnTab: true
+    onActiveFocusChanged: {
+        if (activeFocus && resultRepeater.count > 0) {
+            focusResult(selectedIndex >= 0 ? selectedIndex : 0);
+        }
+    }
 
     WScrollView {
         id: scrollView
@@ -29,6 +123,7 @@ Item {
             width: root.width
 
             Repeater {
+                id: resultRepeater
                 model: app.searchController.searchResultVM
 
                 Rectangle {
@@ -36,14 +131,71 @@ Item {
 
                     property bool isHovered: false
                     property bool isSelected: index === root.selectedIndex
+                    property bool isChecked: root.checkedRevision >= 0 && root.isResultChecked(index)
+                    property string albumLink: model.albumLink
 
-                    color: isSelected || isHovered ? "#759fc7" : "#6c98c4"
+                    color: isSelected || isHovered ? "#759fc7" : (isChecked ? "#688db2" : "#6c98c4")
                     height: 45
                     radius: 10
                     width: parent.width * 0.9
                     x: isSelected ? 0 : (parent.width - width) / 2
                     scale: root.isSearching ? 0 : isSelected ? 0.95 : mouseArea.pressed ? 0.90 : 1.0
                     opacity: root.isSearching ? 0 : 1
+                    activeFocusOnTab: false
+                    border.width: activeFocus ? 2 : 0
+                    border.color: activeFocus ? "#ffffff" : "transparent"
+
+                    Accessible.role: Accessible.CheckBox
+                    Accessible.name: model.name
+                    Accessible.description: "Result " + (index + 1) + " of " + resultRepeater.count + ". " + (isSelected ? "Selected" : "Not selected") + ". " + (isChecked ? "Checked" : "Not checked") + "."
+                    Accessible.focusable: true
+                    Accessible.focused: activeFocus
+                    Accessible.selectable: true
+                    Accessible.selected: isSelected
+                    Accessible.checkable: true
+                    Accessible.checked: isChecked
+                    onIsCheckedChanged: {
+                        if (activeFocus) {
+                            Accessible.valueChanged();
+                        }
+                    }
+
+                    Keys.onReturnPressed: {
+                        root.toggleResultChecked(index);
+                        event.accepted = true;
+                    }
+                    Keys.onEnterPressed: {
+                        root.toggleResultChecked(index);
+                        event.accepted = true;
+                    }
+                    Keys.onSpacePressed: {
+                        root.toggleResultChecked(index);
+                        event.accepted = true;
+                    }
+                    Keys.onUpPressed: {
+                        root.focusResult(index - 1);
+                        event.accepted = true;
+                    }
+                    Keys.onDownPressed: {
+                        root.focusResult(index + 1);
+                        event.accepted = true;
+                    }
+                    Keys.onPressed: (event) => {
+                        if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_D) {
+                            root.addCheckedToDownloads();
+                            event.accepted = true;
+                        } else if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_U) {
+                            root.appendCheckedUrlsToDownloadInput();
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_Home) {
+                            root.focusResult(0);
+                            event.accepted = true;
+                        } else if (event.key === Qt.Key_End) {
+                            root.focusResult(resultRepeater.count - 1);
+                            event.accepted = true;
+                        }
+                    }
+
                     Behavior on scale {
                         NumberAnimation {
                             duration: 150
@@ -67,17 +219,11 @@ Item {
 
                         anchors.fill: parent
                         hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
 
                         onClicked: {
-                            if (root.selectedIndex >= 0 && root.selectedIndex !== index) {
-                                var prevItem = repeater.children[root.selectedIndex];
-                                if (prevItem && prevItem.isHovered) {
-                                    prevItem.isHovered = false;
-                                }
-                            }
-                            rectangle.anchors.horizontalCenter = undefined;
-                            root.selectedIndex = index;
-                            app.searchController.searchResultVM.setSelectedIndex(index);
+                            root.selectResult(index);
+                            rectangle.forceActiveFocus();
                         }
                         onEntered: {
                             if (!isSelected) {
@@ -91,8 +237,22 @@ Item {
                         }
                     }
                     Text {
+                        id: checkboxIndicator
                         anchors.left: parent.left
                         anchors.leftMargin: 10
+                        color: "white"
+                        font.bold: true
+                        font.pointSize: 13
+                        height: parent.height
+                        horizontalAlignment: Text.AlignLeft
+                        text: isChecked ? "[x]" : "[ ]"
+                        verticalAlignment: Text.AlignVCenter
+                        width: 28
+                        Accessible.ignored: true
+                    }
+                    Text {
+                        anchors.left: parent.left
+                        anchors.leftMargin: 40
                         anchors.right: parent.right
                         anchors.rightMargin: 10
                         color: "white"
@@ -117,9 +277,12 @@ Item {
        }
 
        Connections {
-           target: app.searchController.searchResultVM
-           function onSearchCompleted() {
-               root.isSearching = false;
-           }
-       }
+            target: app.searchController.searchResultVM
+            function onSearchCompleted() {
+                root.isSearching = false;
+                if (resultRepeater.count > 0) {
+                    root.focusResult(0);
+                }
+            }
+        }
 }

--- a/src/ui/settings/SettingsPanel.qml
+++ b/src/ui/settings/SettingsPanel.qml
@@ -5,9 +5,23 @@ import QtQml
 import QtQuick.Layouts
 import QtQuick
 Rectangle {
+    id: root
     color: "#2c3e50"
     height: 700
     width: 400
+    Accessible.role: Accessible.Pane
+    Accessible.name: "Settings panel"
+    Accessible.description: "Configure download path, logging, performance, and content preferences."
+    function openLocalFolder(path) {
+        if (!path || path.length === 0) {
+            return;
+        }
+        if (Qt.platform.os === "windows") {
+            Qt.openUrlExternally("file:///" + path);
+        } else {
+            Qt.openUrlExternally("file://" + path);
+        }
+    }
 
     FolderDialog {
         id: folderDialog
@@ -36,8 +50,11 @@ Rectangle {
                 height: parent.height
                 radius: 10
                 width: parent.width * 0.7
+                border.width: downloadPathText.activeFocus ? 2 : 0
+                border.color: downloadPathText.activeFocus ? "#ffffff" : "transparent"
 
                 Text {
+                    id: downloadPathText
                     anchors.fill: parent
                     anchors.leftMargin: 8
                     color: "#ffffff"
@@ -45,19 +62,33 @@ Rectangle {
                     text: "Path: " + app.settings.downloadPath
                     elide: Text.ElideRight
                     verticalAlignment: Text.AlignVCenter
+                    activeFocusOnTab: true
+
+                    Accessible.role: Accessible.Link
+                    Accessible.name: "Open download path in file browser"
+                    Accessible.description: app.settings.downloadPath
+                    Accessible.focusable: true
+                    Accessible.focused: activeFocus
+
+                    Keys.onReturnPressed: {
+                        root.openLocalFolder(app.settings.downloadPath);
+                        event.accepted = true;
+                    }
+                    Keys.onEnterPressed: {
+                        root.openLocalFolder(app.settings.downloadPath);
+                        event.accepted = true;
+                    }
+                    Keys.onSpacePressed: {
+                        root.openLocalFolder(app.settings.downloadPath);
+                        event.accepted = true;
+                    }
                     MouseArea
                     {
                         anchors.fill: parent;
+                        cursorShape: Qt.PointingHandCursor
                         onClicked:
                         {
-                            if (Qt.platform.os === "windows")
-                            {
-                                Qt.openUrlExternally("file:///" +  app.settings.downloadPath);
-                            }
-                            else
-                            {
-                                Qt.openUrlExternally("file://" + app.settings.downloadPath);
-                            }
+                            root.openLocalFolder(app.settings.downloadPath);
                         }
                     }
                 }
@@ -67,6 +98,8 @@ Rectangle {
 
                 height: parent.height
                 label: "Select Path"
+                accessibleName: "Select download path"
+                accessibleDescription: "Open a folder picker to choose where downloads are saved."
                 width: parent.width * 0.25
 
                 onClicked: {
@@ -96,33 +129,55 @@ Rectangle {
                         font.pointSize: 12
                         text: "Enable Logging"
                         verticalAlignment: Text.AlignVCenter
+                        Accessible.role: Accessible.StaticText
+                        Accessible.name: "Enable logging"
                     }
                     Item {
                         Layout.fillWidth: true
                     }
                     Text {
+                        id: openLogPathText
                         color: "#99ffffff"
                         font.pointSize: 12
                         text: "Open Log Path"
                         verticalAlignment: Text.AlignVCenter
+                        activeFocusOnTab: true
+
+                        Accessible.role: Accessible.Link
+                        Accessible.name: "Open log folder in file browser"
+                        Accessible.description: app.logController.logDir
+                        Accessible.focusable: true
+                        Accessible.focused: activeFocus
+
+                        Keys.onReturnPressed: {
+                            root.openLocalFolder(app.logController.logDir);
+                            event.accepted = true;
+                        }
+                        Keys.onEnterPressed: {
+                            root.openLocalFolder(app.logController.logDir);
+                            event.accepted = true;
+                        }
+                        Keys.onSpacePressed: {
+                            root.openLocalFolder(app.logController.logDir);
+                            event.accepted = true;
+                        }
                         MouseArea
                         {
                             width: parent.width
                             height: logrow.height
                             y: logrow.y - parent.y
+                            cursorShape: Qt.PointingHandCursor
                             onClicked:
                             {
-                                if (Qt.platform.os === "windows")
-                                {
-                                    Qt.openUrlExternally("file:///" +  app.logController.logDir);
-                                }
-                                else
-                                {
-                                    Qt.openUrlExternally("file://" +  app.logController.logDir);
-                                }
-
-
+                                root.openLocalFolder(app.logController.logDir);
                             }
+                        }
+                        Rectangle {
+                            anchors.fill: parent
+                            color: "transparent"
+                            border.width: openLogPathText.activeFocus ? 2 : 0
+                            border.color: openLogPathText.activeFocus ? "#ffffff" : "transparent"
+                            radius: 4
                         }
                     }
                 }
@@ -133,6 +188,8 @@ Rectangle {
                 height: parent.height
                 width: parent.parent.width * 0.25
                 fontSize: 13
+                accessibleName: "Enable logging"
+                accessibleDescription: "Turn detailed log output on or off."
                 onValueChanged:
                 {
                     app.settings.setEnableLogging(selectedIndex != 0);
@@ -168,6 +225,8 @@ Rectangle {
                 height: parent.height
                 currentNumber: app.settings.downloadThreads
                 nextNumber: app.settings.downloadThreads
+                accessibleName: "Download threads"
+                accessibleDescription: "Number of download worker threads."
                 onValueChanged:
                 {
                     app.settings.setDownloadThreads(currentNumber);
@@ -218,6 +277,8 @@ Rectangle {
                 height: parent.height
                 currentNumber: app.settings.maxConcurrentDownloadsPerThread
                 nextNumber: app.settings.maxConcurrentDownloadsPerThread
+                accessibleName: "Concurrent downloads per thread"
+                accessibleDescription: "Maximum simultaneous album downloads per worker thread."
                 onValueChanged:
                 {
                     app.settings.setMaxConcurrentDownloadsPerThread(currentNumber);
@@ -252,6 +313,8 @@ Rectangle {
                 height: parent.height
                 width: parent.width * 0.25
                 fontSize: 13
+                accessibleName: "Audio quality"
+                accessibleDescription: "Preferred quality when a format choice is available."
                 onValueChanged:
                 {
                     app.settings.setPreferredAudioQualityInt(selectedIndex);
@@ -288,6 +351,8 @@ Rectangle {
                 height: parent.height
                 width: parent.width * 0.25
                 fontSize: 13
+                accessibleName: "Download art covers"
+                accessibleDescription: "Choose whether to download album cover artwork."
                 onValueChanged:
                 {
                     app.settings.setDownloadArt(selectedIndex != 0);
@@ -329,6 +394,8 @@ Rectangle {
                 height: parent.height
                 width: parent.width * 0.25
                 fontSize: 13
+                accessibleName: "Skip downloaded files"
+                accessibleDescription: "Skip songs that already exist in the destination folder."
                 onValueChanged:
                 {
                     app.settings.setSkipDownloaded(selectedIndex != 0);
@@ -369,6 +436,8 @@ Rectangle {
                 height: parent.height
                 width: parent.width * 0.25
                 fontSize: 13
+                accessibleName: "Check for updates"
+                accessibleDescription: "Check GitHub for a newer app release."
                 onClicked:
                 {
                     app.aboutController.checkForUpdates();

--- a/src/ui/shared/SideButton.qml
+++ b/src/ui/shared/SideButton.qml
@@ -5,18 +5,58 @@ Item {
     width: 100
     height: 100
     property var iconFallback: "qrc:/icons/about.svg";
+    property string accessibleName: labelText.text
+    property string accessibleDescription: ""
 
     // Default properties
     property alias iconSource: icon.source
     property alias label: labelText.text
     signal clicked();
     signal loaded();
+    activeFocusOnTab: true
+
+    Accessible.role: Accessible.Button
+    Accessible.name: accessibleName
+    Accessible.description: accessibleDescription
+    Accessible.focusable: enabled
+    Accessible.focused: activeFocus
+
+    function activateButton() {
+        if (!enabled) {
+            return;
+        }
+        root.clicked();
+    }
+
+    Keys.onReturnPressed: {
+        activateButton();
+        event.accepted = true;
+    }
+    Keys.onEnterPressed: {
+        activateButton();
+        event.accepted = true;
+    }
+    Keys.onSpacePressed: {
+        activateButton();
+        event.accepted = true;
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: "transparent"
+        radius: 8
+        border.width: root.activeFocus ? 2 : 0
+        border.color: root.activeFocus ? "#ffffff" : "transparent"
+    }
+
     MouseArea
     {
         anchors.fill:parent
+        enabled: root.enabled
+        cursorShape: Qt.PointingHandCursor
         onClicked:
         {
-            root.clicked();
+            root.activateButton();
         }
     }
     Column {
@@ -31,6 +71,7 @@ Item {
             source:  "../../../icons/about.svg" // default icon
             anchors.horizontalCenter: parent.horizontalCenter
             fillMode: Image.PreserveAspectFit
+            Accessible.ignored: true
             onStatusChanged: {
                   if (status === Image.Error) {
                       source = iconFallback;
@@ -48,6 +89,7 @@ Item {
             width: parent.width
             horizontalAlignment: Text.AlignHCenter
             color: "white"
+            Accessible.ignored: true
         }
 
     }

--- a/src/ui/shared/WButton.qml
+++ b/src/ui/shared/WButton.qml
@@ -7,11 +7,22 @@ Rectangle {
     property alias label: buttonlabel.text
 
     property alias fontSize : buttonlabel.font.pointSize
-    color: "#6c98c4"
+    property string accessibleName: buttonlabel.text
+    property string accessibleDescription: ""
+    color: mouseArea.containsMouse || activeFocus ? "#5a87b3" : "#6c98c4"
     height: 40
     //width: parent.width * 0.5
     radius: 107
     scale: 1.0
+    border.width: activeFocus ? 2 : 0
+    border.color: activeFocus ? "#ffffff" : "transparent"
+    activeFocusOnTab: true
+
+    Accessible.role: Accessible.Button
+    Accessible.name: accessibleName
+    Accessible.description: accessibleDescription
+    Accessible.focusable: enabled
+    Accessible.focused: activeFocus
 
     Behavior on color {
         ColorAnimation {
@@ -39,12 +50,35 @@ Rectangle {
             to: 1.0
         }
     }
+    function activateButton() {
+        if (!enabled) {
+            return;
+        }
+        shrinkAnim.restart();
+        growAnim.restart();
+        buttonRect.clicked();
+    }
+
+    Keys.onReturnPressed: {
+        activateButton();
+        event.accepted = true;
+    }
+    Keys.onEnterPressed: {
+        activateButton();
+        event.accepted = true;
+    }
+    Keys.onSpacePressed: {
+        activateButton();
+        event.accepted = true;
+    }
+
     MouseArea {
+        id: mouseArea
         anchors.fill: parent
         hoverEnabled: true
+        enabled: buttonRect.enabled
+        cursorShape: Qt.PointingHandCursor
 
-        onEntered: buttonRect.color = "#5a87b3"
-        onExited: buttonRect.color = "#6c98c4"
         onPressed: {
             shrinkAnim.running = true;
         }
@@ -53,7 +87,7 @@ Rectangle {
         }
         onClicked:
         {
-            buttonRect.clicked();
+            buttonRect.activateButton();
         }
     }
     Text {
@@ -69,5 +103,6 @@ Rectangle {
         horizontalAlignment: Text.AlignHCenter
         text: "Add FLAC"
         verticalAlignment: Text.AlignVCenter
+        Accessible.ignored: true
     }
 }

--- a/src/ui/shared/WNumberBoxButton.qml
+++ b/src/ui/shared/WNumberBoxButton.qml
@@ -27,6 +27,7 @@ Text
     }
     property bool isPlus: false
     id: control
+    Accessible.ignored: true
 
     color:"white"
     text: isPlus ? "+" : "-"
@@ -37,6 +38,7 @@ Text
     {
         anchors.fill: parent
         hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
         onEntered: {
 
             onHover.start()


### PR DESCRIPTION
## Accessibility Recovery Series (1/4)

Since the Qt rewrite, the app has became totally unusable with screenreaders, which means blind and visually impaired people aren't able to use it.

The goal of this pull request series is to fix all accessibility issues without changing the way this app looks.

This work consists of 4 pull requests to review and merge separately. I figured it would be better to improve the accessibility of this app rather than maintain my own fork.

The code in this series has been thoroughly tested against download scenarios and is intended to be safe to merge.

This PR series intentionally excludes build/dependency script rewrites so review can stay focused on accessibility behavior.

## Scope of This PR

PR 1/4 restores the core accessibility foundation across shared controls and main panels:
- Keyboard focus and traversal in shared controls and key panels
- Screen reader names/roles/descriptions for core UI sections
- Accessible behavior in result/delegate/dialog surfaces used by search/download/about
- Baseline UI accessibility checks coverage

## Files in This PR

- `scripts/shared/accessibility_tests.py`
- `src/pages/download/DownloaderModel.cpp`
- `src/pages/download/DownloaderModel.h`
- `src/pages/search/SearchResultModel.h`
- `src/ui/Main.qml`
- `src/ui/about/AboutPanel.qml`
- `src/ui/about/UpdateCheckerDialog.qml`
- `src/ui/download/AlbumItem.qml`
- `src/ui/download/DownloadPanel.qml`
- `src/ui/download/DownloadSide.qml`
- `src/ui/search/AlbumImageCaret.qml`
- `src/ui/search/AlbumImageCaretButton.qml`
- `src/ui/search/AlbumInfoSide.qml`
- `src/ui/search/SearchPanel.qml`
- `src/ui/search/SearchResultsList.qml`
- `src/ui/settings/SettingsPanel.qml`
- `src/ui/shared/SideButton.qml`
- `src/ui/shared/WButton.qml`
- `src/ui/shared/WEnumButton.qml`
- `src/ui/shared/WNumberBox.qml`
- `src/ui/shared/WNumberBoxButton.qml`
